### PR TITLE
Refactor agent into modular components

### DIFF
--- a/IMO25/code/api_utils.py
+++ b/IMO25/code/api_utils.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+import os
+import sys
+import json
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+try:
+    from .config import (
+        API_URL_BASE,
+        MODEL_PROVIDER,
+        CEREBRAS_MODEL_DEFAULT,
+    )
+except ImportError:
+    from config import (
+        API_URL_BASE,
+        MODEL_PROVIDER,
+        CEREBRAS_MODEL_DEFAULT,
+    )
+
+
+def get_api_key(agent_type: str) -> str:
+    """Retrieve API key for a given agent role."""
+    if MODEL_PROVIDER == "cerebras":
+        api_key = os.getenv("CEREBRAS_API_KEY")
+        if not api_key:
+            print(
+                "Error: CEREBRAS_API_KEY environment variable not set for Cerebras provider."
+            )
+            print("Please check your .env file or set MODEL_PROVIDER=openrouter.")
+            sys.exit(1)
+        return api_key
+
+    if agent_type == "strategist":
+        api_key = os.getenv("CEO_API_KEY")
+    elif agent_type == "worker":
+        api_key = os.getenv("GENIUS_API_KEY")
+    elif agent_type == "improver":
+        api_key = os.getenv("IMPROVER_API_KEY") or os.getenv("CEO_API_KEY")
+    else:  # verifier and fallback
+        api_key = os.getenv("CEO_API_KEY")
+
+    if not api_key:
+        print(f"Error: API key for {agent_type} not set.")
+        sys.exit(1)
+    return api_key
+
+
+def build_request_payload(
+    system_prompt: str,
+    question_prompt: str,
+    other_prompts: Optional[Any] = None,
+    temperature: float = 0.1,
+    top_p: float = 1.0,
+    max_tokens: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Construct payload for chat completion APIs."""
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": question_prompt},
+    ]
+    if other_prompts:
+        for prompt in other_prompts:
+            messages.append({"role": "user", "content": prompt})
+    payload: Dict[str, Any] = {
+        "messages": messages,
+        "temperature": temperature,
+        "top_p": top_p,
+    }
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    return payload
+
+
+def send_openrouter_request(
+    api_key: str,
+    payload: Dict[str, Any],
+    model_name: str,
+    agent_type: str = "unknown",
+    max_retries: int = 3,
+    telemetry=None,
+):
+    """Send request to OpenRouter API with retry logic."""
+    api_url = API_URL_BASE
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://github.com/lyang36/IMO25",
+        "X-Title": f"IMO25-{agent_type}",
+    }
+    payload["model"] = model_name
+    for attempt in range(max_retries):
+        print(
+            f"[{agent_type.upper()}] Sending request to OpenRouter API ({model_name})... (Attempt {attempt + 1}/{max_retries})"
+        )
+        try:
+            start = time.time()
+            response = requests.post(
+                api_url,
+                headers=headers,
+                data=json.dumps(payload),
+                timeout=(30, 30),
+            )
+            duration = time.time() - start
+            if telemetry:
+                telemetry.record_api_call(duration)
+            response.raise_for_status()
+            response_text = response.text
+            preview = (
+                response_text
+                if len(response_text) <= 500
+                else response_text[:500] + "... [truncated]"
+            )
+            print(f"[{agent_type.upper()}] API request succeeded. Status: {response.status_code}")
+            print(f"[{agent_type.upper()}] Response preview: {preview}")
+            try:
+                if not response_text.strip():
+                    print(f"[{agent_type.upper()}] Warning: Empty response received")
+                    return {"choices": [{"message": {"content": ""}}]}
+                response_json = response.json()
+                return response_json
+            except json.JSONDecodeError as e:
+                print(f"[{agent_type.upper()}] JSON decode error: {e}")
+                print(f"[{agent_type.upper()}] Raw response length: {len(response_text)}")
+                try:
+                    import re
+
+                    json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
+                    if json_match:
+                        partial_json = json_match.group(0)
+                        print(
+                            f"[{agent_type.upper()}] Found potential JSON fragment, length: {len(partial_json)}"
+                        )
+                        return json.loads(partial_json)
+                    print(
+                        f"[{agent_type.upper()}] No JSON-like content found in response"
+                    )
+                except json.JSONDecodeError:
+                    print(f"[{agent_type.upper()}] Failed to parse JSON fragment")
+                print(
+                    f"[{agent_type.upper()}] Raw response (first 1000 chars): {response_text[:1000]}"
+                )
+                return {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "Error: Failed to parse API response"
+                            }
+                        }
+                    ]
+                }
+        except requests.exceptions.Timeout:
+            duration = time.time() - start if "start" in locals() else 0
+            if telemetry:
+                telemetry.record_api_call(duration)
+            print(
+                f"[{agent_type.upper()}] API request timed out (Attempt {attempt + 1}/{max_retries})"
+            )
+            if attempt < max_retries - 1:
+                print(f"[{agent_type.upper()}] Retrying in 2 seconds...")
+                time.sleep(2)
+            else:
+                print(
+                    f"[{agent_type.upper()}] All retry attempts failed. API request timed out."
+                )
+                return {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "Error: API request timed out"
+                            }
+                        }
+                    ]
+                }
+        except requests.exceptions.RequestException as e:
+            duration = time.time() - start if "start" in locals() else 0
+            if telemetry:
+                telemetry.record_api_call(duration)
+            print(f"[{agent_type.upper()}] Error during API request: {e}")
+            if hasattr(e, "response") and e.response is not None:
+                print(
+                    f"[{agent_type.upper()}] Status code: {e.response.status_code}"
+                )
+                print(f"[{agent_type.upper()}] Response text: {e.response.text}")
+            if attempt < max_retries - 1:
+                print(f"[{agent_type.upper()}] Retrying in 2 seconds...")
+                time.sleep(2)
+            else:
+                print(
+                    f"[{agent_type.upper()}] All retry attempts failed. API request failed."
+                )
+                return {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": f"Error: API request failed with exception {e}"
+                            }
+                        }
+                    ]
+                }
+
+
+def send_cerebras_request(
+    api_key: str,
+    payload: Dict[str, Any],
+    model_name: str,
+    agent_type: str = "unknown",
+    telemetry=None,
+):
+    """Send request using Cerebras SDK."""
+    start = time.time()
+    try:
+        try:
+            from cerebras.cloud.sdk import Cerebras
+        except Exception as import_err:
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": f"Error: cerebras-cloud-sdk not installed ({import_err})"
+                        }
+                    }
+                ]
+            }
+        client = Cerebras(api_key=api_key)
+        messages = payload.get("messages", [])
+        temperature = payload.get("temperature", 0.1)
+        top_p = payload.get("top_p", 1.0)
+        max_tokens = payload.get("max_tokens", None)
+        res = client.chat.completions.create(
+            messages=messages,
+            model=model_name or CEREBRAS_MODEL_DEFAULT,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+        )
+        duration = time.time() - start
+        if telemetry:
+            telemetry.record_api_call(duration)
+        try:
+            content = res.choices[0].message.content
+        except Exception:
+            content = ""
+            try:
+                content = res["choices"][0]["message"]["content"]
+            except Exception:
+                content = str(res)
+        return {"choices": [{"message": {"content": content}}]}
+    except Exception as e:
+        duration = time.time() - start
+        if telemetry:
+            telemetry.record_api_call(duration)
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": f"Error: Cerebras request failed with exception {e}"
+                    }
+                }
+            ]
+        }
+
+
+def send_api_request(
+    api_key: str,
+    payload: Dict[str, Any],
+    model_name: str,
+    agent_type: str = "unknown",
+    max_retries: int = 3,
+    telemetry=None,
+):
+    """Router that dispatches to provider-specific request functions."""
+    provider = MODEL_PROVIDER
+    if provider == "cerebras":
+        return send_cerebras_request(
+            api_key, payload, model_name, agent_type=agent_type, telemetry=telemetry
+        )
+    return send_openrouter_request(
+        api_key,
+        payload,
+        model_name,
+        agent_type=agent_type,
+        max_retries=max_retries,
+        telemetry=telemetry,
+    )
+
+
+def extract_text_from_response(response_data: Dict[str, Any]) -> str:
+    """Extract generated text from API response."""
+    try:
+        if "choices" in response_data and response_data["choices"]:
+            message = response_data["choices"][0].get("message", {})
+            content = message.get("content")
+            if content is not None:
+                return content
+            print("Warning: 'content' field not found in message")
+            return ""
+        print("Warning: 'choices' field not found or empty in response")
+        return ""
+    except (KeyError, IndexError, TypeError) as e:
+        print("Error: Could not extract text from the API response.")
+        print(f"Reason: {e}")
+        print("Full API Response:")
+        print(json.dumps(response_data, indent=2))
+        return ""

--- a/IMO25/code/config.py
+++ b/IMO25/code/config.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+STRATEGIST_MODEL_NAME = os.getenv("STRATEGIST_MODEL_NAME", "deepseek/deepseek-r1-0528:free")
+WORKER_MODEL_NAME = os.getenv("WORKER_MODEL_NAME", "deepseek/deepseek-chat-v3-0324:free")
+IMPROVER_MODEL_NAME = os.getenv("IMPROVER_MODEL_NAME", "deepseek/deepseek-chat-v3-0324:free")
+ENABLE_NRPA = os.getenv("NRPA_ENABLED", "1") in ("1", "true", "True", "yes", "YES")
+
+API_URL_BASE = "https://openrouter.ai/api/v1/chat/completions"
+MODEL_PROVIDER = os.getenv("MODEL_PROVIDER", "openrouter").lower()
+CEREBRAS_MODEL_DEFAULT = os.getenv("CEREBRAS_MODEL_DEFAULT", "llama-4-scout-17b-16e-instruct")

--- a/IMO25/code/logging_utils.py
+++ b/IMO25/code/logging_utils.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+import os
+from datetime import datetime
+from typing import Optional, TextIO
+
+_log_file: Optional[TextIO] = None
+_log_directory = "../logs"
+_log_counter_file = os.path.join(_log_directory, "log_counter.txt")
+_log_number: Optional[int] = None
+_verbose_mode = False
+original_print = print
+
+
+def get_timestamp() -> str:
+    """Get current timestamp for logging."""
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def log_print(*args, **kwargs) -> None:
+    """Print with timestamp and also write to log file if set."""
+    timestamp = get_timestamp()
+    message = " ".join(str(arg) for arg in args)
+    timestamped_message = f"[{timestamp}] {message}"
+    original_print(timestamped_message, **kwargs)
+    if _log_file is not None:
+        _log_file.write(timestamped_message + "\n")
+        _log_file.flush()
+
+
+def debug_print(*args, **kwargs) -> None:
+    """Print debug messages only when verbose mode is enabled."""
+    if _verbose_mode:
+        log_print("[DEBUG]", *args, **kwargs)
+
+
+def set_verbose_mode(flag: bool) -> None:
+    global _verbose_mode
+    _verbose_mode = flag
+
+
+def get_log_directory() -> str:
+    return _log_directory
+
+
+def get_next_log_number() -> int:
+    """Get next sequential log number and increment counter."""
+    global _log_counter_file, _log_number
+    if _log_number is not None:
+        return _log_number
+    log_dir = os.path.dirname(_log_counter_file)
+    os.makedirs(log_dir, exist_ok=True)
+    counter = 1
+    try:
+        if os.path.exists(_log_counter_file):
+            with open(_log_counter_file, "r") as f:
+                counter = int(f.read().strip())
+    except Exception:
+        counter = 1
+    try:
+        with open(_log_counter_file, "w") as f:
+            f.write(str(counter + 1))
+    except Exception:
+        pass
+    _log_number = counter
+    return counter
+
+
+def initialize_logging(log_directory: str = "logs") -> str:
+    """Initialize logging directory and return sequential log file path."""
+    global _log_directory
+    _log_directory = log_directory
+    os.makedirs(_log_directory, exist_ok=True)
+    log_number = get_next_log_number()
+    return os.path.join(_log_directory, f"IMO{log_number}.log")
+
+
+def set_log_file(log_file_path: str) -> bool:
+    """Set global log file. Returns True on success."""
+    global _log_file
+    if log_file_path:
+        try:
+            os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+            _log_file = open(log_file_path, "w", encoding="utf-8")
+            return True
+        except Exception as e:
+            log_print(f"Error opening log file {log_file_path}: {e}")
+            return False
+    return True
+
+
+def close_log_file() -> None:
+    """Close the global log file if open."""
+    global _log_file
+    if _log_file is not None:
+        _log_file.close()
+        _log_file = None

--- a/IMO25/code/strategy_selector.py
+++ b/IMO25/code/strategy_selector.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+import json
+from typing import List, Dict, Any, Tuple, Optional
+
+try:
+    from .prompts import (
+        STRATEGIST_ENUM_PROMPT,
+        WORKER_SKETCH_PROMPT,
+        LIGHTWEIGHT_VERIFIER_PROMPT,
+        STRATEGY_REFINEMENT_PROMPT,
+        parse_strategies_list,
+        parse_viability_score,
+    )
+    from .telemetry_ext import nrpa_start, nrpa_iteration, nrpa_end
+    from .nrpa import run_nrpa, NRPA_LEVELS, NRPA_ITER, NRPA_ALPHA, NRPA_MAX_DEPTH
+    from .config import STRATEGIST_MODEL_NAME, WORKER_MODEL_NAME, IMPROVER_MODEL_NAME
+    from .api_utils import (
+        build_request_payload,
+        send_api_request,
+        extract_text_from_response,
+        get_api_key,
+    )
+except ImportError:
+    from prompts import (
+        STRATEGIST_ENUM_PROMPT,
+        WORKER_SKETCH_PROMPT,
+        LIGHTWEIGHT_VERIFIER_PROMPT,
+        STRATEGY_REFINEMENT_PROMPT,
+        parse_strategies_list,
+        parse_viability_score,
+    )
+    from telemetry_ext import nrpa_start, nrpa_iteration, nrpa_end
+    from nrpa import run_nrpa, NRPA_LEVELS, NRPA_ITER, NRPA_ALPHA, NRPA_MAX_DEPTH
+    from config import STRATEGIST_MODEL_NAME, WORKER_MODEL_NAME, IMPROVER_MODEL_NAME
+    from api_utils import (
+        build_request_payload,
+        send_api_request,
+        extract_text_from_response,
+        get_api_key,
+    )
+
+
+class StrategySelector:
+    """Abstract base class for strategy selection."""
+
+    def __init__(self, api_client_funcs, strategist_system_prompt: str):
+        self.api_client_funcs = api_client_funcs
+        self.strategist_system_prompt = strategist_system_prompt
+
+    def select_strategy(
+        self, problem_statement: str, other_prompts, telemetry=None
+    ) -> str:
+        raise NotImplementedError
+
+
+class SingleStrategySelector(StrategySelector):
+    """Strategy selector that makes a single call to the CEO."""
+
+    def select_strategy(
+        self, problem_statement: str, other_prompts, telemetry=None
+    ) -> str:
+        print("[STRATEGY] Using single strategy selection.")
+        strategist_payload = self.api_client_funcs["build_request_payload"](
+            system_prompt=self.strategist_system_prompt,
+            question_prompt=problem_statement,
+            other_prompts=other_prompts,
+        )
+        strategist_response = self.api_client_funcs["send_api_request"](
+            get_api_key("strategist"),
+            strategist_payload,
+            model_name=STRATEGIST_MODEL_NAME,
+            agent_type="strategist",
+            telemetry=telemetry,
+        )
+        return self.api_client_funcs["extract_text_from_response"](strategist_response)
+
+
+class NRPAStrategySelector(StrategySelector):
+    """Strategy selector that runs the full NRPA loop."""
+
+    def select_strategy(
+        self, problem_statement: str, other_prompts, telemetry=None
+    ) -> str:
+        print("[NRPA] Starting Strategist with NRPA Strategy Search...")
+        strategies = enumerate_initial_strategies(
+            problem_statement, other_prompts, self.strategist_system_prompt
+        )
+        if not strategies:
+            print(
+                "[NRPA] No strategies returned; falling back to original strategist flow."
+            )
+            return self._fallback_strategy(problem_statement, other_prompts, telemetry)
+        cache: Dict[str, Any] = {}
+
+        def children_provider(step: int, prefix: Tuple[str, ...]) -> List[str]:
+            if step == 0:
+                return strategies
+            return generate_refinements(list(prefix), problem_statement, cache, telemetry)
+
+        def score_fn(seq: List[str]) -> float:
+            if not seq:
+                return 0.0
+            path_description = " -> ".join(seq)
+            sketch = run_strategic_simulation(path_description, problem_statement, telemetry)
+            score, reason = lightweight_score_sketch(sketch, telemetry)
+            print(
+                f"[NRPA] Scored sequence: {path_description[:100]}... -> {score:.3f} ({reason[:50]})"
+            )
+            return score
+
+        print(
+            f"[NRPA] Starting search: L={NRPA_LEVELS}, N={NRPA_ITER}, Alpha={NRPA_ALPHA}, MaxDepth={NRPA_MAX_DEPTH}"
+        )
+        if telemetry:
+            nrpa_start(
+                telemetry,
+                {
+                    "num_candidates": len(strategies),
+                    "levels": NRPA_LEVELS,
+                    "iterations": NRPA_ITER,
+                    "alpha": NRPA_ALPHA,
+                    "max_depth": NRPA_MAX_DEPTH,
+                },
+            )
+        best_score, best_seq = run_nrpa(
+            levels=NRPA_LEVELS,
+            iterations=NRPA_ITER,
+            alpha=NRPA_ALPHA,
+            initial_strategies=strategies,
+            children_provider=children_provider,
+            score_fn=score_fn,
+            cache=cache,
+        )
+        chosen = " -> ".join(best_seq) if best_seq else strategies[0]
+        print(f"[NRPA] Best sequence (score={best_score:.3f}): {chosen}")
+        if telemetry:
+            nrpa_end(telemetry, {"best_score": best_score, "best_sequence": chosen})
+        return chosen
+
+    def _fallback_strategy(self, problem_statement, other_prompts, telemetry):
+        strategist_payload = self.api_client_funcs["build_request_payload"](
+            system_prompt=self.strategist_system_prompt,
+            question_prompt=problem_statement,
+            other_prompts=other_prompts,
+        )
+        strategist_response = self.api_client_funcs["send_api_request"](
+            get_api_key("strategist"),
+            strategist_payload,
+            model_name=STRATEGIST_MODEL_NAME,
+            agent_type="strategist",
+            telemetry=telemetry,
+        )
+        return self.api_client_funcs["extract_text_from_response"](strategist_response)
+
+
+def run_strategic_simulation(
+    path_description: str, problem_statement: str, telemetry=None
+) -> str:
+    print(f"[NRPA] Running strategic simulation for path: {path_description}")
+    worker_prompt = WORKER_SKETCH_PROMPT.format(
+        problem_statement=problem_statement[:4000], path_description=path_description
+    )
+    payload = build_request_payload(
+        system_prompt="",
+        question_prompt=worker_prompt,
+        temperature=0.2,
+        top_p=0.95,
+        max_tokens=800,
+    )
+    resp = send_api_request(
+        get_api_key("worker"),
+        payload,
+        model_name=WORKER_MODEL_NAME,
+        agent_type="worker",
+        telemetry=telemetry,
+    )
+    sketch_text = extract_text_from_response(resp)
+    print(f"[NRPA] DEBUG: Generated sketch (first 500 chars): {sketch_text[:500]}")
+    return sketch_text
+
+
+def generate_refinements(
+    path_prefix: List[str],
+    problem_statement: str,
+    cache: Dict[str, Any],
+    telemetry=None,
+) -> List[str]:
+    from hashlib import md5
+
+    cache_key = md5(f"refine::{'|'.join(path_prefix)}".encode()).hexdigest()
+    if cache_key in cache:
+        print(
+            f"[NRPA] Using cached refinements for prefix: {' -> '.join(path_prefix[:2])}"
+        )
+        return cache[cache_key]
+    prefix_text = " -> ".join(path_prefix) if path_prefix else "(initial strategies)"
+    print(f"[NRPA] Generating refinements for prefix: {prefix_text}")
+    prompt = STRATEGY_REFINEMENT_PROMPT.format(path_prefix=prefix_text)
+    payload = build_request_payload(
+        system_prompt="",
+        question_prompt=prompt,
+        temperature=0.3,
+        top_p=0.9,
+        max_tokens=600,
+    )
+    resp = send_api_request(
+        get_api_key("strategist"),
+        payload,
+        model_name=STRATEGIST_MODEL_NAME,
+        agent_type="strategist",
+        telemetry=telemetry,
+    )
+    text = extract_text_from_response(resp)
+    refinements = parse_strategies_list(text)
+    seen = set()
+    unique: List[str] = []
+    for r in refinements:
+        if r not in seen and len(r) > 10 and len(r) < 200:
+            seen.add(r)
+            unique.append(r)
+    result = unique[:5]
+    cache[cache_key] = result
+    print(f"[NRPA] Generated {len(result)} refinements")
+    return result
+
+
+def lightweight_score_sketch(sketch: str, telemetry=None):
+    prompt = LIGHTWEIGHT_VERIFIER_PROMPT.replace("{sketch}", sketch)
+    payload = build_request_payload(
+        system_prompt="",
+        question_prompt=prompt,
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=200,
+    )
+    resp = send_api_request(
+        get_api_key("verifier"),
+        payload,
+        model_name=IMPROVER_MODEL_NAME,
+        agent_type="verifier",
+        telemetry=telemetry,
+    )
+    text = ""
+    try:
+        text = extract_text_from_response(resp)
+    except Exception as e:
+        text = f"(no-text; extract error: {e})"
+    print(f"[NRPA] DEBUG: Verifier response text: {text[:500]}")
+    score = 0.0
+    reason = ""
+    parsed_score = None
+    parsed_reason = None
+    try:
+        print(
+            f"[NRPA] DEBUG: Attempting to parse viability score from text: {text[:200]}"
+        )
+        parsed_score, parsed_reason = parse_viability_score(text or "")
+        print(
+            f"[NRPA] DEBUG: parse_viability_score returned: score={parsed_score}, reason={parsed_reason}"
+        )
+        try:
+            score = float(parsed_score)
+        except Exception as e:
+            print(
+                f"[NRPA] DEBUG: Failed to convert parsed_score to float: {parsed_score}, error: {e}"
+            )
+            score = 0.0
+        if score < 0.0 or score > 1.0:
+            print(f"[NRPA] DEBUG: Score out of range [0,1]: {score}")
+            score = 0.0
+        reason = (parsed_reason or "").strip()
+    except Exception as e:
+        print(f"[NRPA] DEBUG: Exception in parse_viability_score: {e}")
+        score = 0.0
+        reason = f"parse error: {e}"
+    if not reason:
+        snippet = (text or "").strip()
+        if len(snippet) > 160:
+            snippet = snippet[:160] + "..."
+        reason = snippet or "no reason"
+    if score == 0.0 and "parse error" in reason:
+        print(
+            f"[NRPA] DEBUG: Failed to parse viability score from verifier response:"
+        )
+        print(f"[NRPA] DEBUG: Full response text: {text}")
+        print(
+            f"[NRPA] DEBUG: Parsed score: {parsed_score}, reason: {parsed_reason}"
+        )
+    print(f"[NRPA] Lightweight score: {score:.3f}. Reason: {reason}")
+    return score, reason
+
+
+def enumerate_initial_strategies(
+    problem_statement: str, other_prompts, strategist_system_prompt: str
+):
+    enum_prompt = STRATEGIST_ENUM_PROMPT.format(problem_statement=problem_statement)
+    payload = build_request_payload(
+        system_prompt=strategist_system_prompt,
+        question_prompt=enum_prompt,
+        other_prompts=other_prompts,
+        temperature=0.2,
+        top_p=0.9,
+        max_tokens=600,
+    )
+    resp = send_api_request(
+        get_api_key("strategist"),
+        payload,
+        model_name=STRATEGIST_MODEL_NAME,
+        agent_type="strategist",
+    )
+    text = extract_text_from_response(resp)
+    strategies = parse_strategies_list(text)
+    print("[NRPA] Initial strategies:")
+    for s in strategies:
+        print(f" - {s}")
+    return strategies

--- a/IMO25/code/telemetry_system.py
+++ b/IMO25/code/telemetry_system.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+import json
+import os
+from datetime import datetime
+from typing import Any
+
+try:
+    from .logging_utils import get_next_log_number
+except ImportError:
+    from logging_utils import get_next_log_number
+
+
+class TelemetrySystem:
+    """Track and persist agent metrics and events."""
+
+    def __init__(self, log_directory: str = "../logs") -> None:
+        self.log_directory = log_directory
+        self.metrics = {
+            "start_time": None,
+            "end_time": None,
+            "total_api_calls": 0,
+            "api_call_durations": [],
+            "agent_iterations": 0,
+            "verification_passes": 0,
+            "verification_failures": 0,
+            "strategy_changes": 0,
+            "solution_found": False,
+        }
+        self.events: list[dict[str, Any]] = []
+
+    def start_session(self) -> None:
+        self.metrics["start_time"] = datetime.now().isoformat()
+        self.log_event("SESSION_START", "Telemetry session started")
+
+    def end_session(self) -> None:
+        self.metrics["end_time"] = datetime.now().isoformat()
+        self.log_event("SESSION_END", "Telemetry session ended")
+        self.save_metrics()
+
+    def log_event(self, event_type: str, description: str) -> None:
+        self.events.append(
+            {
+                "type": event_type,
+                "description": description,
+                "timestamp": datetime.now().isoformat(),
+            }
+        )
+
+    def record_api_call(self, duration: float) -> None:
+        self.metrics["total_api_calls"] += 1
+        self.metrics["api_call_durations"].append(duration)
+
+    def record_iteration(self) -> None:
+        self.metrics["agent_iterations"] += 1
+
+    def record_verification_result(self, passed: bool) -> None:
+        if passed:
+            self.metrics["verification_passes"] += 1
+        else:
+            self.metrics["verification_failures"] += 1
+
+    def record_strategy_change(self) -> None:
+        self.metrics["strategy_changes"] += 1
+        self.log_event("STRATEGY_CHANGE", "Agent strategy was reassessed by CEO")
+
+    def record_solution_found(self) -> None:
+        self.metrics["solution_found"] = True
+        self.log_event("SOLUTION_FOUND", "Agent found a correct solution")
+
+    def save_metrics(self) -> None:
+        log_number = get_next_log_number() - 1
+        metrics_file_path = os.path.join(
+            self.log_directory, f"IMO{log_number}_telemetry.json"
+        )
+        total_duration = 0.0
+        if self.metrics["start_time"] and self.metrics["end_time"]:
+            start = datetime.fromisoformat(self.metrics["start_time"])
+            end = datetime.fromisoformat(self.metrics["end_time"])
+            total_duration = (end - start).total_seconds()
+        avg_api_duration = 0.0
+        if self.metrics["api_call_durations"]:
+            avg_api_duration = sum(self.metrics["api_call_durations"]) / len(
+                self.metrics["api_call_durations"]
+            )
+        full_metrics = {
+            **self.metrics,
+            "total_duration_seconds": total_duration,
+            "average_api_call_duration": avg_api_duration,
+            "events": self.events,
+        }
+        try:
+            with open(metrics_file_path, "w") as f:
+                json.dump(full_metrics, f, indent=2)
+            print(f"[TELEMETRY] Metrics saved to {metrics_file_path}")
+        except Exception as e:
+            print(f"[TELEMETRY] Error saving metrics: {e}")


### PR DESCRIPTION
## Summary
- centralize environment and model configuration in `config` and streamline API helpers in `api_utils`
- add `PolicyManager`-based NRPA with state-independent action hashing
- decompose monolithic `agent.py` into modules for logging, telemetry, and strategy selection

## Testing
- `cd IMO25 && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893d2084c5c83278528b1912ababfb7